### PR TITLE
Record simplifications, performance, fixed compiler warnings, Eclipse project for Linux

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="addon/Face/bin"/>
-	<classpathentry kind="src" output="addon/Google/bin" path="addon/Google/src"/>
-	<classpathentry exported="true" kind="lib" path="addon/Google/lib/google-speech.jar"/>
-	<classpathentry kind="src" output="addon/Microsoft/bin" path="addon/Microsoft/src"/>
-	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/jni4net.j-0.8.8.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Speech.j4n.jar"/>
-	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect.j4n.jar"/>
-	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect2.j4n.jar"/>
-	<classpathentry kind="src" output="addon/Nuance9/bin" path="addon/Nuance9/src"/>
-	<classpathentry kind="src" output="addon/NuanceCloud/bin" path="addon/NuanceCloud/src"/>
-	<classpathentry kind="src" output="app/chess/bin" path="app/chess/src"/>
-	<classpathentry kind="src" output="app/quiz/bin" path="app/quiz/src"/>
-	<classpathentry kind="src" output="core/bin" path="core/src"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/commons.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/platform.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/jnaerator-0.9.5.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/jportaudio.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/json.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/jetty.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/js-14.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/JNativeHook.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-core.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-common.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/freemarker.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/hat.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/turbojpeg.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/batik-gui-util-1.8.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/xuggle-xuggler-5.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/webcam-capture-0.3.10.jar"/>
-	<classpathentry exported="true" kind="lib" path="core/lib/bridj-0.6.2.jar"/>
-	<classpathentry kind="output" path="bin"/>
+<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+<classpathentry kind="lib" path="addon/Face/bin"/>
+<classpathentry kind="src" output="addon/Google/bin" path="addon/Google/src"/>
+<classpathentry exported="true" kind="lib" path="addon/Google/lib/google-speech.jar"/>
+<classpathentry kind="src" output="addon/Microsoft/bin" path="addon/Microsoft/src"/>
+<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/jni4net.j-0.8.8.0.jar"/>
+<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Speech.j4n.jar"/>
+<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect.j4n.jar"/>
+<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect2.j4n.jar"/>
+<classpathentry kind="src" output="addon/Nuance9/bin" path="addon/Nuance9/src"/>
+<classpathentry kind="src" output="addon/NuanceCloud/bin" path="addon/NuanceCloud/src"/>
+<classpathentry kind="src" output="app/chess/bin" path="app/chess/src"/>
+<classpathentry kind="src" output="app/quiz/bin" path="app/quiz/src"/>
+<classpathentry kind="src" output="core/bin" path="core/src"/>
+<classpathentry exported="true" kind="lib" path="core/lib/commons.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/platform.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/jnaerator-0.9.5.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/jportaudio.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/json.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/jetty.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/js-14.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/JNativeHook.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-core.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-common.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/freemarker.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/hat.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/turbojpeg.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/batik-gui-util-1.8.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/xuggle-xuggler-5.4.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/webcam-capture-0.3.10.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/bridj-0.6.2.jar"/>
+<classpathentry exported="true" kind="lib" path="core/lib/furhat-skill.jar"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="addon/Face/bin"/>
+	<classpathentry kind="src" output="addon/Google/bin" path="addon/Google/src"/>
+	<classpathentry exported="true" kind="lib" path="addon/Google/lib/google-speech.jar"/>
+	<classpathentry kind="src" output="addon/Microsoft/bin" path="addon/Microsoft/src"/>
+	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/jni4net.j-0.8.8.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Speech.j4n.jar"/>
+	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect.j4n.jar"/>
+	<classpathentry exported="true" kind="lib" path="addon/Microsoft/lib/IrisTK.Net.Kinect2.j4n.jar"/>
+	<classpathentry kind="src" output="addon/Nuance9/bin" path="addon/Nuance9/src"/>
+	<classpathentry kind="src" output="addon/NuanceCloud/bin" path="addon/NuanceCloud/src"/>
+	<classpathentry kind="src" output="app/chess/bin" path="app/chess/src"/>
+	<classpathentry kind="src" output="app/quiz/bin" path="app/quiz/src"/>
+	<classpathentry kind="src" output="core/bin" path="core/src"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/commons.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/platform.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/jnaerator-0.9.5.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/jportaudio.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/json.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/jetty.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/js-14.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/JNativeHook.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-core.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/docking-frames-common.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/freemarker.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/hat.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/turbojpeg.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/batik-gui-util-1.8.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/xuggle-xuggler-5.4.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/webcam-capture-0.3.10.jar"/>
+	<classpathentry exported="true" kind="lib" path="core/lib/bridj-0.6.2.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>IrisTK</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addon/Microsoft/src/iristk/kinect/KinectCameraView.java
+++ b/addon/Microsoft/src/iristk/kinect/KinectCameraView.java
@@ -69,7 +69,9 @@ public class KinectCameraView implements CameraViewDecorator, KinectBodyListener
 
 	@Override
 	public synchronized void onBodiesReceived(Record bodyRec) {
-		this.bodySet = bodyRec.getList("bodies");
+		@SuppressWarnings("unchecked")
+		List<Body> downcast = (List<Body>) bodyRec.getList("bodies");
+		this.bodySet = downcast;
 		lastBodySeen = System.currentTimeMillis();
 
 		float height = kinect.getCameraViewHeight();

--- a/core/src/iristk/system/EventMonitorPanel.java
+++ b/core/src/iristk/system/EventMonitorPanel.java
@@ -90,7 +90,9 @@ public class EventMonitorPanel extends JPanel implements EventListener {
 		if (event.getName().equals("monitor.system.start")) {
 			eventTracks.setupTracks();
 		} else if (event.getName().equals("monitor.module.state")) {
-			eventTracks.monitorState(event.getSender(), event.getList("states"));
+			@SuppressWarnings("unchecked")
+			List<String> lstates = (List<String>) event.getList("states");
+			eventTracks.monitorState(event.getSender(), lstates);
 		} else {
 			eventTracks.addEvent(event);
 		}

--- a/core/src/iristk/util/Converters.java
+++ b/core/src/iristk/util/Converters.java
@@ -15,10 +15,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class Converters {
 	
-	public static Object asType(Object object, Class type) {
+	public static Object asType(Object object, Class<?> type) {
 		if (object == null)
 			return null;
 		else if (object.getClass() == type)
@@ -45,7 +46,7 @@ public class Converters {
 			return object;
 	}
 
-	private static Record asDerivedRecord(Record object, Class type) {
+	private static Record asDerivedRecord(Record object, Class<?> type) {
 		try {
 			Record record = (Record) type.newInstance();
 			record.putAllExceptNull(object);
@@ -59,10 +60,7 @@ public class Converters {
 	}
 
 	public static String asString(Object object) {
-		if (object == null)
-			return null;
-		else
-			return object.toString();
+		return asString(object, null);
 	}
 	/**
 	 * Returns object as a String, unless it is null in which case def is returned.
@@ -71,10 +69,7 @@ public class Converters {
 	 * @return String version of object
 	 */
 	public static String asString(Object object, String def) {
-		if (object == null)
-			return def;
-		else
-			return object.toString();
+		return Objects.toString(object, def);
 	}	
 
 	public static boolean asBoolean(Object object) {
@@ -91,7 +86,7 @@ public class Converters {
 		else if (object instanceof String) 
 			return !((String)object).equalsIgnoreCase("false");
 		else if (object instanceof Collection) 
-			return ((Collection)object).size() > 0;
+			return ((Collection<?>)object).size() > 0;
 			else return true;
 	}
 
@@ -102,20 +97,22 @@ public class Converters {
 			return asBoolean(object);
 	}
 
-	public static List asList(Object object) {
+	public static List<Object> asList(Object object) {
 		if (object == null)
 			return null;
-		else if (object instanceof List)
-			return (List)object;
-		else if (object instanceof Record)
-			return new ArrayList(((Record)object).getValues());
+		else if (object instanceof List) {
+			@SuppressWarnings("unchecked")
+			final List<Object> result = (List<Object>)object;
+			return result;
+		} else if (object instanceof Record)
+			return new ArrayList<>(((Record)object).getValues());
 		else if (object instanceof Collection)
-			return new ArrayList((Collection)object);
+			return new ArrayList<>((Collection<?>)object);
 		else 
 			return Arrays.asList(object);
 	}
 	
-	public static List asList(Object... objects) {
+	public static List<Object> asList(Object... objects) {
 		return Arrays.asList(objects);	
 	}
 
@@ -125,7 +122,7 @@ public class Converters {
 		else if (object instanceof Record)
 			return (Record)object;
 		else if (object instanceof Map)
-			return new Record((Map)object);
+			return new Record((Map<?,?>)object);
 		else 
 			return null;
 	}
@@ -161,8 +158,7 @@ public class Converters {
 		} else if (object instanceof String) {
 			try {
 				String s = (String)object;
-				if (s.contains(","))
-					s = s.replace(",", ".");
+				s = s.replace(',', '.');
 				return Double.parseDouble(s);
 			} catch (NumberFormatException e) {
 				return null;

--- a/core/src/iristk/util/NameFilter.java
+++ b/core/src/iristk/util/NameFilter.java
@@ -11,8 +11,9 @@
 package iristk.util;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 
 /**
@@ -31,7 +32,7 @@ import java.util.regex.Pattern;
  */
 public class NameFilter {
 
-	private static HashMap<String,NameFilter> cachedFilters = new HashMap<String,NameFilter>();
+	private static final ConcurrentMap<String,NameFilter> CACHED_FILTERS = new ConcurrentHashMap<String,NameFilter>();
 	
 	/**
 	 * A static filter that accepts anything
@@ -71,14 +72,13 @@ public class NameFilter {
 	/**
 	 * Creates a filter by parsing a pattern string
 	 */
-	public static synchronized NameFilter compile(String patt) {
-		if (cachedFilters.containsKey(patt))
-			return cachedFilters.get(patt);
-		if (!patt.matches("[A-Za-z0-9_\\!\\.\\*; ]*"))
-			throw new IllegalArgumentException("NamePattern illegal: " + patt);
-		NameFilter filter = new NameFilter(patt);
-		cachedFilters.put(patt, filter);
-		return filter;
+	public static NameFilter compile(String patt) {
+		return CACHED_FILTERS.computeIfAbsent(patt, p -> {
+			if (!patt.matches("[A-Za-z0-9_\\!\\.\\*; ]*"))
+				throw new IllegalArgumentException("NamePattern illegal: " + patt);
+			NameFilter filter = new NameFilter(patt);
+			return filter;
+		});
 	}
 
 	@Override

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -281,15 +281,15 @@ public class Record implements Cloneable {
 					} else if (dynamicFields.containsKey(field)) {
 						result = dynamicFields.get(field);
 					} else {
-						Object dynamicFieldResult = null;
+						Object dynamicFieldIndexLookupResult = null;
 	 					try {
 							int i = Integer.parseInt(field);
 							if (i < dynamicFields.size()) {
-								dynamicFieldResult = dynamicFields.values().toArray()[i];
+								dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
 							}
 						} catch (NumberFormatException e) {
 						}
-						result = dynamicFieldResult;
+						result = dynamicFieldIndexLookupResult;
 					}
 				}
 			}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -282,7 +282,7 @@ public class Record implements Cloneable {
 						result = dynamicFields.computeIfAbsent(field, key -> {
 							Object dynamicFieldIndexLookupResult = null;
 		 					try {
-								int i = Integer.parseInt(field);
+								int i = Integer.parseInt(key);
 								if (i < dynamicFields.size()) {
 									dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
 								}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -278,18 +278,24 @@ public class Record implements Cloneable {
 							e.printStackTrace();
 						}
 						result = getFieldResult;
-					} else if (dynamicFields.containsKey(field)) {
-						result = dynamicFields.get(field);
 					} else {
-						Object dynamicFieldResult = null;
-	 					try {
-							int i = Integer.parseInt(field);
-							if (i < dynamicFields.size()) {
-								dynamicFieldResult = dynamicFields.values().toArray()[i];
+						result = dynamicFields.compute(field, (key, oldValue) -> {
+							final Object newValue;
+							if (oldValue == null) {
+								Object dynamicFieldIndexLookupResult = null;
+			 					try {
+									int i = Integer.parseInt(field);
+									if (i < dynamicFields.size()) {
+										dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
+									}
+								} catch (NumberFormatException e) {
+								}
+			 					newValue = dynamicFieldIndexLookupResult;
+							} else {
+								newValue = oldValue;
 							}
-						} catch (NumberFormatException e) {
-						}
-						result = dynamicFieldResult;
+							return newValue;
+						});
 					}
 				}
 			}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -70,7 +71,10 @@ import javafx.util.converter.LocalDateTimeStringConverter;
  * <p> There are also convenience functions for getting a value of the right type. For example, {@code myRecord.getInt("foo:bar")} will try to convert the value to an Integer. If this fails the method will return null.
  * <p> Using kleen stars (*), it is also possible to search the hierarchy using the {@code has()} method. Thus, {@code myRecord.has("*:bar")} will return true.   
  *  */
+//@SuppressWarnings("restriction")
 public class Record implements Cloneable {
+	
+	public static final Charset JSON_CHARSET = Utils.IO_CHARSET;
 	
 	private static final Object[] EMPTY_VARARGS_ARRAY = null;
 	
@@ -632,7 +636,7 @@ public class Record implements Cloneable {
 	}
 
 	public static Record fromJSON(URL resource) throws IOException, JsonToRecordException {
-		return fromJSON(IOUtils.toString(resource.openStream(), "UTF-8"));
+		return fromJSON(IOUtils.toString(resource.openStream(), JSON_CHARSET.name()));
 	}
 	
 	/**
@@ -653,6 +657,7 @@ public class Record implements Cloneable {
 	 */
 	public static Record fromJSON(String string) throws JsonToRecordException {
 		try {
+//			@SuppressWarnings("deprecation")
 			JsonObject jsonObject = JsonObject.readFrom(string);
 			return parseJsonObject(jsonObject);
 		} catch (ParseException e) {
@@ -662,6 +667,7 @@ public class Record implements Cloneable {
 	
 	public static Object fromJSONValue(String string) throws JsonToRecordException {
 		try {
+//			@SuppressWarnings("deprecation")
 			JsonValue json = JsonObject.readFrom(string);
 			return parseJsonValue(json);
 		} catch (ParseException e) {

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -279,22 +279,16 @@ public class Record implements Cloneable {
 						}
 						result = getFieldResult;
 					} else {
-						result = dynamicFields.compute(field, (key, oldValue) -> {
-							final Object newValue;
-							if (oldValue == null) {
-								Object dynamicFieldIndexLookupResult = null;
-			 					try {
-									int i = Integer.parseInt(field);
-									if (i < dynamicFields.size()) {
-										dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
-									}
-								} catch (NumberFormatException e) {
+						result = dynamicFields.computeIfAbsent(field, key -> {
+							Object dynamicFieldIndexLookupResult = null;
+		 					try {
+								int i = Integer.parseInt(field);
+								if (i < dynamicFields.size()) {
+									dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
 								}
-			 					newValue = dynamicFieldIndexLookupResult;
-							} else {
-								newValue = oldValue;
+							} catch (NumberFormatException e) {
 							}
-							return newValue;
+		 					return dynamicFieldIndexLookupResult;
 						});
 					}
 				}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -279,16 +279,22 @@ public class Record implements Cloneable {
 						}
 						result = getFieldResult;
 					} else {
-						result = dynamicFields.computeIfAbsent(field, key -> {
-							Object dynamicFieldIndexLookupResult = null;
-		 					try {
-								int i = Integer.parseInt(field);
-								if (i < dynamicFields.size()) {
-									dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
+						result = dynamicFields.compute(field, (key, oldValue) -> {
+							final Object newValue;
+							if (oldValue == null) {
+								Object dynamicFieldIndexLookupResult = null;
+			 					try {
+									int i = Integer.parseInt(field);
+									if (i < dynamicFields.size()) {
+										dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
+									}
+								} catch (NumberFormatException e) {
 								}
-							} catch (NumberFormatException e) {
+			 					newValue = dynamicFieldIndexLookupResult;
+							} else {
+								newValue = oldValue;
 							}
-		 					return dynamicFieldIndexLookupResult;
+							return newValue;
 						});
 					}
 				}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -282,7 +282,7 @@ public class Record implements Cloneable {
 						result = dynamicFields.computeIfAbsent(field, key -> {
 							Object dynamicFieldIndexLookupResult = null;
 		 					try {
-								int i = Integer.parseInt(key);
+								int i = Integer.parseInt(field);
 								if (i < dynamicFields.size()) {
 									dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
 								}

--- a/core/src/iristk/util/Record.java
+++ b/core/src/iristk/util/Record.java
@@ -278,24 +278,18 @@ public class Record implements Cloneable {
 							e.printStackTrace();
 						}
 						result = getFieldResult;
+					} else if (dynamicFields.containsKey(field)) {
+						result = dynamicFields.get(field);
 					} else {
-						result = dynamicFields.compute(field, (key, oldValue) -> {
-							final Object newValue;
-							if (oldValue == null) {
-								Object dynamicFieldIndexLookupResult = null;
-			 					try {
-									int i = Integer.parseInt(field);
-									if (i < dynamicFields.size()) {
-										dynamicFieldIndexLookupResult = dynamicFields.values().toArray()[i];
-									}
-								} catch (NumberFormatException e) {
-								}
-			 					newValue = dynamicFieldIndexLookupResult;
-							} else {
-								newValue = oldValue;
+						Object dynamicFieldResult = null;
+	 					try {
+							int i = Integer.parseInt(field);
+							if (i < dynamicFields.size()) {
+								dynamicFieldResult = dynamicFields.values().toArray()[i];
 							}
-							return newValue;
-						});
+						} catch (NumberFormatException e) {
+						}
+						result = dynamicFieldResult;
 					}
 				}
 			}

--- a/core/src/iristk/util/Utils.java
+++ b/core/src/iristk/util/Utils.java
@@ -22,6 +22,8 @@ import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -35,7 +37,10 @@ import java.util.regex.Matcher;
 
 import sun.misc.Unsafe;
 
+//@SuppressWarnings("restriction")
 public class Utils {
+	
+	public static final Charset IO_CHARSET = StandardCharsets.UTF_8;
 
 	public static String readTextFile(File file) throws IOException {
 		/*
@@ -53,8 +58,8 @@ public class Utils {
 	}
 
 	public static String readString(InputStream in) throws IOException {
-		//return IOUtils.toString(in, "UTF-8");
-		try(java.util.Scanner s = new java.util.Scanner(in, "UTF-8")){
+		//return IOUtils.toString(in, DEFAULT_CHARSET.name());
+		try(java.util.Scanner s = new java.util.Scanner(in, IO_CHARSET.name())){
 			s.useDelimiter("\\A");
 			return s.hasNext() ? s.next() : "";	
 		}
@@ -63,7 +68,7 @@ public class Utils {
 	public static void writeTextFile(File file, String string) throws IOException {
 		if (file.getParentFile() != null && !file.getParentFile().exists())
 			file.getParentFile().mkdirs();
-		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), IO_CHARSET.name()));
 		bw.write(string);
 		bw.close();
 	}


### PR DESCRIPTION
- Including Eclipse _.project_ and _.classpath_ files generated on Windows with `iristk.exe` so that Linux-based systems can import the Eclipse project
- Fixed compiler warnings from raw generic types
- Simplified usage of the `Map` interface in the accessor methods of the `Record` class. This also makes processing large amounts of `Event` instances significantly faster due to the fact that many said methods call themselves recursively.